### PR TITLE
feat: add peers

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -21,48 +21,70 @@ class HomePage extends StatelessWidget {
             child: Consumer<Chains>(
                 builder: (context, chains, child) => const ChainSyncStatus())),
         drawer: Drawer(
-            child: ListView(padding: EdgeInsets.zero, children: [
-          SizedBox(
-              height: MediaQuery.of(context).padding.top + kToolbarHeight + 8,
-              child: DrawerHeader(
-                decoration: const BoxDecoration(
-                  color: Colors.pink,
+            child: TextButtonTheme(
+                data: TextButtonThemeData(
+                  style: TextButton.styleFrom(
+                      alignment: Alignment.centerLeft,
+                      padding: EdgeInsets.zero,
+                      foregroundColor: Colors.grey.shade300),
                 ),
-                child: Text('Chains',
-                    style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                        color: Colors.white, fontFamily: 'Syncopate-Bold')),
-              )),
-          // Add configured chains from provider
-          ...context.read<Chains>().chains.map((e) => ExpansionTile(
-                leading: e.logo,
-                title: Text(e.name,
-                    style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                        color: Colors.black, fontFamily: 'Syncopate-Bold')),
-                initiallyExpanded: true,
-                children: e.parachains
-                    .map((e) => ListTile(
-                          leading: e.logo,
-                          title: Text(e.name,
+                child: ListView(padding: EdgeInsets.zero, children: [
+                  SizedBox(
+                      height: MediaQuery.of(context).padding.top +
+                          kToolbarHeight +
+                          8,
+                      child: DrawerHeader(
+                        decoration: const BoxDecoration(
+                          color: Colors.pink,
+                        ),
+                        child: Text('Chains',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleLarge!
+                                .copyWith(
+                                    color: Colors.white,
+                                    fontFamily: 'Syncopate-Bold')),
+                      )),
+                  // Add configured chains from provider
+                  ...context.read<Chains>().chains.map((e) => ExpansionTile(
+                        title: TextButton.icon(
+                          icon: e.logo,
+                          label: Text(e.name,
                               style: Theme.of(context)
                                   .textTheme
                                   .titleMedium!
                                   .copyWith(
                                       color: Colors.black,
                                       fontFamily: 'Syncopate-Bold')),
-                          contentPadding: const EdgeInsets.only(left: 25),
-                          onTap: () async {
+                          onPressed: () async {
                             // Select the chain
                             await context.read<Chains>().select(e);
                             // Then close the drawer
                             Navigator.pop(context);
                           },
-                        ))
-                    .toList(),
-                onExpansionChanged: (bool expanded) async {
-                  // Select the chain
-                  await context.read<Chains>().select(e);
-                },
-              ))
-        ])));
+                        ),
+                        initiallyExpanded: true,
+                        children: e.parachains
+                            .map((e) => ListTile(
+                                  leading: e.logo,
+                                  title: Text(e.name,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium!
+                                          .copyWith(
+                                              color: Colors.black,
+                                              fontFamily: 'Syncopate-Bold')),
+                                  contentPadding:
+                                      const EdgeInsets.only(left: 25),
+                                  onTap: () async {
+                                    // Select the chain
+                                    await context.read<Chains>().select(e);
+                                    // Then close the drawer
+                                    Navigator.pop(context);
+                                  },
+                                ))
+                            .toList(),
+                      ))
+                ]))));
   }
 }

--- a/lib/pages/status.dart
+++ b/lib/pages/status.dart
@@ -17,10 +17,10 @@ class ChainSyncStatus extends StatelessWidget {
         child: Consumer<Chain>(
             builder: (context, chain, child) => Column(
                 mainAxisAlignment: MainAxisAlignment.center,
-                children: test(context, chain))));
+                children: buildChain(context, chain))));
   }
 
-  List<Widget> test(BuildContext context, Chain chain) {
+  List<Widget> buildChain(BuildContext context, Chain chain) {
     if (chain is Parachain) {
       return <Widget>[
         // Relay chain
@@ -45,6 +45,8 @@ class ChainSyncStatus extends StatelessWidget {
         ] else ...[
           const BlinkText('Syncing', duration: Duration(seconds: 1)),
         ],
+        const SizedBox(height: 10),
+        ...buildPeers(context, chain.relayChain),
         const SizedBox(height: 50),
         // Parachain
         const Text('Parachain:'),
@@ -67,7 +69,9 @@ class ChainSyncStatus extends StatelessWidget {
           ),
         ] else ...[
           const BlinkText('Syncing', duration: Duration(seconds: 1)),
-        ]
+        ],
+        const SizedBox(height: 10),
+        ...buildPeers(context, chain)
       ];
     }
 
@@ -92,7 +96,20 @@ class ChainSyncStatus extends StatelessWidget {
         ),
       ] else ...[
         const BlinkText('Syncing', duration: Duration(seconds: 1)),
-      ]
+      ],
+      const SizedBox(height: 20),
+      ...buildPeers(context, chain)
+    ];
+  }
+
+  List<Widget> buildPeers(BuildContext context, Chain chain) {
+    return <Widget>[
+      const Text('Peers:'),
+      Text(chain.peers.toString(),
+          style: Theme.of(context)
+              .textTheme
+              .titleLarge!
+              .copyWith(color: Colors.black, fontFamily: 'Syncopate-Bold')),
     ];
   }
 }


### PR DESCRIPTION
Adds peers via periodic `system_health` rpc call ([as per Substrate Connect](https://github.com/paritytech/substrate-connect/blob/3911d973b7e7883f763515ce74a53faaf4048922/projects/extension/src/content/ClientWithExtension.ts#L72-L84)).

Also improves the relay chain selection, with expansion now only on arrow toggle.

Closes #12 